### PR TITLE
Contributing file helper #3

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -1,1 +1,45 @@
-We encourage contributions from the community and welcome collaborations for extension to other priority conservation waterbodies for Atlantic salmon. You can ask questions or submit bug reports through the [issues page](https://github.com/danStich/dia/issues). Please search issues and ensure that a similar issue does not already exist before submitting a new issue. If you would like to contribute improvements or modifications directly to the repository, you can fork the repository and submit a merge request so those contributions can be reviewed.
+
+5. **Submit a Pull Request**  
+Push your changes to your forked repository and submit a pull request (PR) to the main repository. Include a clear description of the changes you’ve made and reference related issues, if any.
+
+---
+
+## 3. **Reporting Issues**
+If you encounter a bug, have a feature request, or find something unclear in the documentation, please open an issue in the GitHub repository.
+
+### How to Report an Issue
+1. **Search for Existing Issues**  
+Before opening a new issue, search the existing issues to see if your concern has already been reported or addressed.
+
+2. **Create a New Issue**  
+If no existing issue matches your concern, create a new issue using the appropriate template. Include:
+- A clear and descriptive title
+- Steps to reproduce the issue (if applicable)
+- The expected behavior
+- The actual behavior
+- Environment details (e.g., operating system, R version)
+
+---
+
+## 4. **Seeking Support**
+For general questions or help using the `dia` package:
+- Check the [documentation](https://danstich.github.io/dia).
+- Review the [FAQs](https://github.com/danStich/dia/wiki/FAQs) (if available).
+- Post your question in the [Discussions](https://github.com/danStich/dia/discussions) tab (if enabled).  
+
+---
+
+## 5. **Development Standards**
+To maintain code quality and consistency, please follow these guidelines:
+- **Coding Style**: Adhere to the [tidyverse style guide](https://style.tidyverse.org/).
+- **Testing**: Write tests for new features or bug fixes using the `testthat` framework.
+- **Documentation**: Ensure all functions have clear and concise Roxygen2 documentation.
+
+---
+
+## 6. **Acknowledgment and Recognition**
+We value and appreciate all contributions. Contributors are recognized in the project’s [Contributors file](https://github.com/danStich/dia/graphs/contributors) and the release notes of major updates.
+
+---
+
+By participating in this project, you agree to these guidelines. Thank you for contributing to `dia` and helping to make it a better tool for the community!

--- a/Contributing.md
+++ b/Contributing.md
@@ -1,3 +1,37 @@
+# Community Guidelines for the `dia` Package
+
+Welcome to the `dia` repository! We’re excited to have you here. To ensure a positive and productive experience for everyone, please follow these guidelines when contributing to or engaging with the project.
+
+---
+
+## 1. **Code of Conduct**
+We are committed to fostering an open, welcoming, and inclusive community. Please review and adhere to the [Contributor Covenant Code of Conduct](https://www.contributor-covenant.org/version/2/0/code_of_conduct/) when interacting with others in this project.
+
+---
+
+## 2. **How to Contribute**
+We welcome contributions to improve the `dia` package. Contributions can include:
+- Reporting bugs
+- Proposing new features
+- Improving documentation
+- Submitting code (e.g., fixing bugs, adding functionality)
+
+### Contribution Process
+1. **Fork the Repository**  
+   Create a copy of this repository under your GitHub account using the "Fork" button.
+
+2. **Create a Branch**  
+   Create a new branch in your forked repository for your changes:
+
+```git checkout -b feature-or-bug-description```
+
+3. **Make Changes**  
+Make your changes in the new branch. Ensure your code adheres to the project’s coding standards.
+
+4. **Test Your Changes**  
+Run all automated tests to verify that your changes do not break existing functionality:z
+
+```devtools::test()```
 
 5. **Submit a Pull Request**  
 Push your changes to your forked repository and submit a pull request (PR) to the main repository. Include a clear description of the changes you’ve made and reference related issues, if any.

--- a/Contributing.md
+++ b/Contributing.md
@@ -2,6 +2,7 @@
 
 Welcome to the `dia` repository! We’re excited to have you here. To ensure a positive and productive experience for everyone, please follow these guidelines when contributing to or engaging with the project.
 
+
 ---
 
 ## 1. **Code of Conduct**


### PR DESCRIPTION
Expand Community Guidelines:
Populate the Contributing.md file with clear instructions for contributing, reporting issues, and seeking support. Include a code of conduct for contributors.
In the pull request I added a potential formatted template you can use.


This template I suggest is to improve Helping and Contributing guidelines. 